### PR TITLE
feat: add configurable markdown conversion

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -8,6 +8,17 @@ download_images: true           # true = скачивать изображени
 max_articles_per_feed: 35        # ограничение на количество за прогон (страхуемся от флуда)
 user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) NewsGrabber/1.0"
 
+# Конвертер HTML → Markdown
+markdown_converter:
+  engine: html2text  # html2text | pypandoc | markitdown
+  html2text:
+    description: "Простая библиотека на Python"
+  pypandoc:
+    description: "Обёртка над pandoc, нужен установленный binary"
+    extra_args: []
+  markitdown:
+    description: "Проект Microsoft для точного перевода в Markdown"
+
 # Глобальные фильтры
 include_keywords: ["нейросети", "machine learning", "python", "deep learning", "наука", "программирование", "ИИ"]
 exclude_keywords: ["вакансия", "джун", "интервью", "маркетинг"]


### PR DESCRIPTION
## Summary
- replace trafilatura/readability pipeline with newspaper4k
- add pluggable HTML→Markdown converters (html2text, pypandoc, MarkItDown)
- document converter settings in config and revert dependency tracking (use uv to manage deps)

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b3137d1c988320855b4ffd82ad5b28