### PR TITLE
fix: support newspaper4k API change

### DIFF
--- a/main.py
+++ b/main.py
@@ -193,7 +193,12 @@ def extract_article(session: requests.Session, url: str, conv_cfg: Dict) -> Arti
     resp.raise_for_status()
 
     art = NPArticle(url)
-    art.set_html(resp.text)
+    # newspaper4k <=0.9 had `set_html`, newer versions expect `download(input_html=...)`
+    if hasattr(art, "set_html"):
+        art.set_html(resp.text)
+    else:
+        # fall back to the new API while avoiding a second network request
+        art.download(input_html=resp.text)
     art.parse()
 
     content_html = art.article_html or art.html or resp.text


### PR DESCRIPTION
## Summary
- handle newspaper4k API change by using `download(input_html=...)` when `set_html` is unavailable

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_68b329635c5083209ceee2d77cac03d9