### PR TITLE
Switch to rating-based article filtering

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -11,6 +11,7 @@ retention_days: 60               # авто-удаление заметок ст
 min_chars: 600                   # минимальная длина статьи (отбор "шумных" коротышей)
 download_images: true           # true = скачивать изображения локально и переписывать ссылки
 max_articles_per_feed: 35        # ограничение на количество за прогон (страхуемся от флуда)
+rating_threshold: 5.0            # чем выше значение, тем меньше статей будет
 user_agent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) NewsGrabber/1.0"
 
 # Конвертер HTML → Markdown


### PR DESCRIPTION
## Summary
- switch article filtering from keywords to rating_store.predict_rating
- prefix saved Markdown filenames with their rating and log rating at debug level
- add configurable rating_threshold (default 5.0)

## Testing
- `python -m py_compile main.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b5483abe148320a0cea87acb3fa2ff